### PR TITLE
refactor: use logical operators instead of bitwise in conditionals

### DIFF
--- a/C/IN_AutoMutualInfoStats.c
+++ b/C/IN_AutoMutualInfoStats.c
@@ -41,7 +41,7 @@ double IN_AutoMutualInfoStats_40_gaussian_fmmi(const double y[], const int size)
     // find first minimum of automutual information
     double fmmi = tau;
     for(int i = 1; i < tau-1; i++){
-        if(ami[i] < ami[i-1] & ami[i] < ami[i+1]){
+        if(ami[i] < ami[i-1] && ami[i] < ami[i+1]){
             fmmi = i;
             // printf("found minimum at %i\n", i);
             break;

--- a/C/PD_PeriodicityWang.c
+++ b/C/PD_PeriodicityWang.c
@@ -63,13 +63,13 @@ int PD_PeriodicityWang_th0_01(const double * y, const int size){
         slopeIn = acf[i] - acf[i-1];
         slopeOut = acf[i+1] - acf[i];
         
-        if(slopeIn < 0 & slopeOut > 0)
+        if(slopeIn < 0 && slopeOut > 0)
         {
             // printf("trough at %i\n", i);
             troughs[nTroughs] = i;
             nTroughs += 1;
         }
-        else if(slopeIn > 0 & slopeOut < 0)
+        else if(slopeIn > 0 && slopeOut < 0)
         {
             // printf("peak at %i\n", i);
             peaks[nPeaks] = i;

--- a/C/SB_BinaryStats.c
+++ b/C/SB_BinaryStats.c
@@ -37,7 +37,7 @@ double SB_BinaryStats_diff_longstretch0(const double y[], const int size){
     int maxstretch0 = 0;
     int last1 = 0;
     for(int i = 0; i < size-1; i++){
-        if(yBin[i] == 1 | i == size-2){
+        if(yBin[i] == 1 || i == size-2){
             double stretch0 = i - last1;
             if(stretch0 > maxstretch0){
                 maxstretch0 = stretch0;
@@ -75,7 +75,7 @@ double SB_BinaryStats_mean_longstretch1(const double y[], const int size){
     int maxstretch1 = 0;
     int last1 = 0;
     for(int i = 0; i < size-1; i++){
-        if(yBin[i] == 0 | i == size-2){
+        if(yBin[i] == 0 || i == size-2){
             double stretch1 = i - last1;
             if(stretch1 > maxstretch1){
                 maxstretch1 = stretch1;

--- a/C/SP_Summaries.c
+++ b/C/SP_Summaries.c
@@ -83,7 +83,7 @@ int welch(const double y[], const int size, const int NFFT, const double Fs, con
     *Pxx = malloc(Nout * sizeof(double));
     for(int i = 0; i < Nout; i++){
         (*Pxx)[i] = P[i]/KMU*dt;
-        if(i>0 & i < Nout-1){
+        if(i>0 && i < Nout-1){
             (*Pxx)[i] *= 2;
         }
     }
@@ -148,7 +148,7 @@ double SP_Summaries_welch_rect(const double y[], const int size, const char what
         w[i] = 2*PI*f[i];
         Sw[i] = S[i]/(2*PI);
         //printf("w[%i]=%1.3f, Sw[%i]=%1.3f\n", i, w[i], i, Sw[i]);
-        if(isinf(Sw[i]) | isinf(-Sw[i])){
+        if(isinf(Sw[i]) || isinf(-Sw[i])){
             return 0;
         }
     }

--- a/C/splinefit.c
+++ b/C/splinefit.c
@@ -603,7 +603,7 @@ int splinefit(const double *y, const int size, double *yOut)
     
     int breakInd = 1;
     for(int i = 0; i < size; i++){
-        if(i >= breaks[breakInd] & breakInd<nBreaks-1)
+        if(i >= breaks[breakInd] && breakInd<nBreaks-1)
             breakInd += 1;
         for(int j = 0; j < nSpline; j++){
             xsB[i*nSpline+j] = i - breaks[breakInd-1];


### PR DESCRIPTION
Feel free to reject, minor cleanup. A few conditionals use bitwise &/| where logical &&/|| is meant.

closes: https://github.com/DynamicsAndNeuralSystems/catch22/issues/30