### PR TITLE
fix: free msDti3 in DN_OutlierInclude_abs_001

### DIFF
--- a/C/DN_OutlierInclude.c
+++ b/C/DN_OutlierInclude.c
@@ -211,6 +211,7 @@ double DN_OutlierInclude_abs_001(const double y[], const int size)
 
     free(highInds);
     free(yAbs);
+    free(msDti3);
     free(msDti4);
     
     return outputScalar;


### PR DESCRIPTION
was allocated same as msDti4 below, just not freed