### PR TITLE
Speed up MATLAB mex build by caching shared C object files

### DIFF
--- a/wrap_Matlab/mexAll.m
+++ b/wrap_Matlab/mexAll.m
@@ -12,16 +12,31 @@ CFileNames = {CFiles.name};
 % Add path to the c file names
 includeFiles = cellfun(@(x) fullfile(basePath, x), CFileNames, 'UniformOutput', false);
 
+% Compile the shared files (M_wrapper.c plus everything in basePath) to
+% object files once, rather than recompiling all of them from source for
+% every one of the ~24 features below:
+sourcesToCache = [{'M_wrapper.c'}, includeFiles];
+objDir = tempname;
+mkdir(objDir);
+cleanupObj = onCleanup(@() rmdir(objDir,'s'));
+fprintf('Compiling %u shared C files (once)...\n',numel(sourcesToCache));
+for i = 1:numel(sourcesToCache)
+    mex(ipath{:}, '-c', '-outdir', objDir, sourcesToCache{i});
+end
+objFiles = dir(objDir);
+objFiles = fullfile(objDir, {objFiles(~[objFiles.isdir]).name});
+
 % Get function names
 featureNames = GetAllFeatureNames(true);
 
-% mex all feature functions separately
+% mex all feature functions separately, linking each against the cached
+% shared objects instead of recompiling them
 numFeatures = length(featureNames);
 for i = 1:numFeatures
     featureName = featureNames{i};
 
     fprintf('[%u/%u]: Compiling %s...\n', i,numFeatures,featureName);
-    mex(ipath{:}, ['catch22_', featureName,'.c'], 'M_wrapper.c', includeFiles{:})
+    mex(ipath{:}, ['catch22_', featureName,'.c'], objFiles{:})
     fprintf('\n');
 end
 


### PR DESCRIPTION
## Summary
- `wrap_Matlab/mexAll.m` compiled each of the 24 feature mex files as a separate `mex` call, and every call was handed the full set of ~24 shared C source files (`helper_functions.c`, `stats.c`, `fft.c`, ...) alongside `M_wrapper.c` and the one feature-specific wrapper -- so every shared file was recompiled from scratch 24 times over.
- This compiles the shared files to object files once with `mex -c -outdir`, then links each small per-feature wrapper against the cached objects.
- ~3.4x faster locally (62s -> 18s on macOS/clang). Output verified bit-identical against the previous build (same feature values on a fixed seed, across a spread of feature functions).

## Test plan
- [x] Ran `mexAll` end-to-end on macOS, all 24 features compile successfully
- [x] Compared feature outputs (`CO_FirstMin_ac`, `DN_Mean`, `SP_Summaries_welch_rect_centroid`) on a fixed-seed input against a build from the unmodified `mexAll.m` -- bit-identical
- [ ] Not tested on Windows/Linux -- the change only adds `-c -outdir` object-compile steps ahead of the existing per-feature mex calls, no new platform-specific logic